### PR TITLE
No GUI response when XML loading fails

### DIFF
--- a/src/org/primaresearch/page/viewer/EventListener.java
+++ b/src/org/primaresearch/page/viewer/EventListener.java
@@ -319,13 +319,13 @@ public class EventListener implements SelectionListener, TaskListener, KeyListen
 			 @Override
 			 public void run()
 			 {
-				// create a dialog with ok and cancel buttons and a question icon
+				// create a dialog with an OK button
 				 MessageBox dialog =
 				     new MessageBox(Display.getDefault().getActiveShell(), SWT.OK);
 				 dialog.setText("XML Load Error");
 				 dialog.setMessage("An XML loading error occured. Please ensure XML validity and try again.");
 
-				 // open dialog and await user selection
+				 // open dialog and await confirmation
 				 dialog.open();
 			 }
 		});

--- a/src/org/primaresearch/page/viewer/EventListener.java
+++ b/src/org/primaresearch/page/viewer/EventListener.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Item;
+import org.eclipse.swt.widgets.MessageBox;
 import org.primaresearch.dla.page.layout.PageLayout;
 import org.primaresearch.dla.page.layout.physical.shared.LowLevelTextType;
 import org.primaresearch.page.viewer.dla.XmlDocumentLayoutLoader;
@@ -41,6 +42,7 @@ import org.primaresearch.page.viewer.ui.views.DocumentView;
  * Event listener/handler
  * 
  * @author Christian Clausner
+ * @author Jake Sebright
  *
  */
 public class EventListener implements SelectionListener, TaskListener, KeyListener {
@@ -165,6 +167,7 @@ public class EventListener implements SelectionListener, TaskListener, KeyListen
 	@Override
 	public void taskFinished(final Task task) {
 		try {
+			// Task Succeeded
 			if (task.isSuccessfull()) {
 				//Image Loader
 				if (task instanceof ImageLoader) {
@@ -174,7 +177,15 @@ public class EventListener implements SelectionListener, TaskListener, KeyListen
 				else if (task instanceof XmlDocumentLayoutLoader) {
 					onXmlLoaderFinished((XmlDocumentLayoutLoader)task);
 				}
-			}		
+			}
+			// Task Failed
+			else
+			{
+				//Xml Loader
+				if (task instanceof XmlDocumentLayoutLoader) {
+					onXmlLoaderFailed((XmlDocumentLayoutLoader)task);
+				}
+			}
 		} catch (Exception exc) {
 			exc.printStackTrace(); //TODO
 		}
@@ -183,6 +194,8 @@ public class EventListener implements SelectionListener, TaskListener, KeyListen
 		pageViewer.processNextTask();
 	}
 	
+
+
 	/**
 	 * Called when an image has been loaded 
 	 */
@@ -295,6 +308,29 @@ public class EventListener implements SelectionListener, TaskListener, KeyListen
 		} catch (Exception exc) {
 			exc.printStackTrace(); //TODO
 		}
+	}
+	
+	/**
+	 * Called when an XML file has failed
+	 */
+	private void onXmlLoaderFailed(XmlDocumentLayoutLoader task) {
+		Display.getDefault().asyncExec(new Runnable()
+		{
+			 @Override
+			 public void run()
+			 {
+				// create a dialog with ok and cancel buttons and a question icon
+				 MessageBox dialog =
+				     new MessageBox(Display.getDefault().getActiveShell(), SWT.OK);
+				 dialog.setText("XML Load Error");
+				 dialog.setMessage("An XML loading error occured. Please ensure XML validity and try again.");
+
+				 // open dialog and await user selection
+				 dialog.open();
+			 }
+		});
+		
+		
 	}
 	
 	/**


### PR DESCRIPTION
I downloaded PAGE Viewer in order to view and validate ALTO OCR on top of corresponding images. When I launched the program and opened my XML file, the application hung with no response. I downloaded the source code to figure out why, and it turns out my ALTO file was missing a tag! I wished I had known this!

In response, I added to the application a dialog box notifying a user when their XML is invalid. I thought it may be nice to add this to the master so others are not left in the same confusion.

<img width="1026" alt="screen shot 2017-08-31 at 9 11 17 am" src="https://user-images.githubusercontent.com/6678669/29930732-772baa5a-8e2c-11e7-9138-f709d2666247.png">
