### PR TITLE
Enabled JP2 support

### DIFF
--- a/src/org/primaresearch/page/viewer/EventListener.java
+++ b/src/org/primaresearch/page/viewer/EventListener.java
@@ -293,7 +293,7 @@ public class EventListener implements SelectionListener, TaskListener, KeyListen
 							//Select image manually
 						    FileDialog fd = new FileDialog(pageViewer.getMainWindow().getShell(), SWT.OPEN);
 						    fd.setText("Select Image");
-						    String[] filterExt = { "*.tif", "*.jpg", "*.png"/*, "*.jp2"*/ };
+						    String[] filterExt = { "*.tif", "*.jpg", "*.png", "*.jp2" };
 						    fd.setFilterExtensions(filterExt);
 						    filePath = fd.open();
 						}


### PR DESCRIPTION
I wanted to use the viewer for JP2 images. When looking at the code, I noticed that the JP2 file option was simply commented out. I removed the comment, and the viewer now seems to work seamlessly with JP2 images. Is there any particular reason this was commented out? Is there any reason for it not to be uncommented now to allow JP2 support?