### PR TITLE
Show baselines

### DIFF
--- a/src/org/primaresearch/page/viewer/PageViewer.java
+++ b/src/org/primaresearch/page/viewer/PageViewer.java
@@ -69,7 +69,7 @@ public class PageViewer {
 		}
 		
 		//Resolve
-		if (imageFilePath != null && resolveDir != null) 
+		if (imageFilePath != null && resolveDir != null && ! new File(imageFilePath).isAbsolute()) 
 			imageFilePath = resolveDir + (resolveDir.endsWith(File.separator) ? "" : File.separator) + imageFilePath;
 
         Display display = new Display();

--- a/src/org/primaresearch/page/viewer/ui/render/DrawingHelper.java
+++ b/src/org/primaresearch/page/viewer/ui/render/DrawingHelper.java
@@ -49,6 +49,27 @@ public class DrawingHelper {
 	}
 	
 	/**
+	 * Draws the given line string
+	 */
+	public static void drawMultiline(GC gc, Color color, Polygon coords) {
+		int polyline[] = new int[coords.getSize()*2];
+
+		for (int i=0; i<coords.getSize(); i++) {
+			Point p = coords.getPoint(i);
+			polyline[i*2] = p.x;
+			polyline[i*2+1] = p.y;
+		}
+
+		gc.setForeground(color);
+		gc.setBackground(color);
+		gc.setAlpha(150);
+		int w = gc.getLineWidth();
+		gc.setLineWidth(w * 2);
+		gc.drawPolyline(polyline);
+		gc.setLineWidth(w);
+	}
+
+	/**
 	 * Draws a line with arrow end
 	 */
 	public static void drawArrow(GC gc, int x1, int y1, int x2, int y2, ArrowShape arrow) {

--- a/src/org/primaresearch/page/viewer/ui/views/DocumentImageView.java
+++ b/src/org/primaresearch/page/viewer/ui/views/DocumentImageView.java
@@ -102,9 +102,9 @@ public class DocumentImageView extends DocumentView implements DocumentListener,
 	    imageCanvas.addMouseTrackListener(this);
 	    imageCanvas.addMouseMoveListener(this);
 	    
-		parent.addMouseWheelListener(imageCanvas);
-		//parent.addMouseMoveListener(imageCanvas);
-		parent.addMouseWheelListener(this);
+		imageCanvas.addMouseWheelListener(imageCanvas);
+		//imageCanvas.addMouseMoveListener(imageCanvas);
+		imageCanvas.addMouseWheelListener(this);
 
 	    tooltip = new PageElementTooltip(viewPane.getShell());
 	    tooltip.activateHoverHelp(imageCanvas);
@@ -748,7 +748,8 @@ public class DocumentImageView extends DocumentView implements DocumentListener,
 
 	@Override
 	public void mouseScrolled(MouseEvent e) {
-		if ((e.stateMask & SWT.MOD1) != 0) { //CTRL
+		// non-CTRL already handled by SWTImageCanvas
+		if ((e.stateMask & (SWT.CTRL | SWT.COMMAND)) != 0) {
 			if (e.count > 0)
 				zoomIn();
 			else

--- a/src/org/primaresearch/page/viewer/ui/views/DocumentImageView.java
+++ b/src/org/primaresearch/page/viewer/ui/views/DocumentImageView.java
@@ -554,7 +554,7 @@ public class DocumentImageView extends DocumentView implements DocumentListener,
 
 		//RegionRef
 		if (element instanceof RegionRef) {
-			Region region = docLayout.getRegion(((RegionRef)element).getRegionId(), true);
+			Region region = (Region)docLayout.getRegion(((RegionRef)element).getRegionId());
 			if (region != null)	{
 				return region.getCoords().getBoundingBox().getCenter();
 			}
@@ -608,7 +608,7 @@ public class DocumentImageView extends DocumentView implements DocumentListener,
 
 		//RegionRef (centre = centre of bounding box)
 		if (element instanceof RegionRef) {
-			Region region = (Region)docLayout.getRegion(((RegionRef)element).getRegionId(), true);
+			Region region = (Region)docLayout.getRegion(((RegionRef)element).getRegionId());
 			if (region != null)	
 				ret = region.getCoords().getBoundingBox().getCenter();
 		}

--- a/src/org/primaresearch/page/viewer/ui/views/DocumentImageView.java
+++ b/src/org/primaresearch/page/viewer/ui/views/DocumentImageView.java
@@ -40,6 +40,7 @@ import org.primaresearch.dla.page.layout.physical.ContentObject;
 import org.primaresearch.dla.page.layout.physical.Region;
 import org.primaresearch.dla.page.layout.physical.shared.LowLevelTextType;
 import org.primaresearch.dla.page.layout.physical.shared.RegionType;
+import org.primaresearch.dla.page.layout.physical.text.impl.TextLine;
 import org.primaresearch.maths.geometry.Point;
 import org.primaresearch.maths.geometry.Polygon;
 import org.primaresearch.page.viewer.Document;
@@ -302,6 +303,11 @@ public class DocumentImageView extends DocumentView implements DocumentListener,
 		gc.setLineWidth(1);
 		for (ContentIterator it = docLayout.iterator(LowLevelTextType.TextLine); it.hasNext(); ) {
 			ContentObject region = it.next();
+			if (region instanceof TextLine &&
+					((TextLine)region).getBaseline() != null) {
+				Polygon baseline = ((TextLine)region).getBaseline();
+				DrawingHelper.drawMultiline(gc, getContentObjectColor(region), baseline);
+			}
 			if (region.getCoords() != null) {
 				Polygon coords = region.getCoords();
 				DrawingHelper.drawPolygon(gc, getContentObjectColor(region), coords);

--- a/src/uky/article/imageviewer/views/SWTImageCanvas.java
+++ b/src/uky/article/imageviewer/views/SWTImageCanvas.java
@@ -421,10 +421,17 @@ public class SWTImageCanvas extends Canvas implements MouseWheelListener, MouseL
 
 	@Override
 	public void mouseScrolled(MouseEvent e) {
-		if ((e.stateMask & SWT.MOD1) == 0) { //No CTRL
-			ScrollBar scrollBar = getVerticalBar();
-			scrollBar.setSelection(scrollBar.getSelection()-e.count*10);
-			scrollVertically(scrollBar);
+		// CTRL already handled by DocumentImageView
+		if ((e.stateMask & (SWT.CTRL | SWT.COMMAND)) == 0) {
+			if ((e.stateMask & (SWT.SHIFT | SWT.ALT)) != 0) {
+				ScrollBar scrollBar = getHorizontalBar();
+				scrollBar.setSelection(scrollBar.getSelection()-e.count*10);
+				scrollHorizontally(scrollBar);
+			} else {
+				ScrollBar scrollBar = getVerticalBar();
+				scrollBar.setSelection(scrollBar.getSelection()-e.count*10);
+				scrollVertically(scrollBar);
+			}
 		}
 	}
 


### PR DESCRIPTION
![page-viewer-baselines](https://user-images.githubusercontent.com/38561704/99114672-75e1a400-25f1-11eb-950d-4702acf8b28d.png)

This is the bare minimum. You might want to add a new button to switch this on or off. Perhaps Aletheia already has an icon for that?

Also, I had to import `org.primaresearch.dla.page.layout.physical.text.impl.TextLine`, because there is no interface which gives `get_Baseline()`.